### PR TITLE
Adds filter Options for warnings similar to swift lint in danger  

### DIFF
--- a/Sources/DangerSwiftKantoku/DangerDSL+.swift
+++ b/Sources/DangerSwiftKantoku/DangerDSL+.swift
@@ -12,6 +12,8 @@ extension DangerDSL {
     public var kantoku: Kantoku {
         .init(
             workingDirectoryPath: utils.exec("pwd"),
+            modifiedFiles: git.modifiedFiles,
+            createdFiles: git.createdFiles,
             markdownCommentExecutor: { markdown($0) },
             inlineCommentExecutor: { message(message: $0, file: $1, line: $2) },
             normalCommentExecutor: { message($0) },

--- a/Sources/DangerSwiftKantoku/Kantoku+IssueComments.swift
+++ b/Sources/DangerSwiftKantoku/Kantoku+IssueComments.swift
@@ -45,28 +45,17 @@ extension Kantoku {
         
     }
     
-    func post(_ summaries: [PostableIssueSummary],
-                 as level: CommentLevel,
-          targetFilesNmes: [File]? = nil) {
+    func post(_ summaries: [PostableIssueSummary], as level: CommentLevel) {
         for summary in summaries {
             let message = summary.issueMessage
             let filePath = summary.documentLocation?.relativePath(against: workingDirectoryPath)
 
-
             if let filePath = filePath {
                 let lineNumber = filePath.queries?.endingLineNumber
-                if let targetFilesNmes = targetFilesNmes {
-                    if !(targetFilesNmes.contains(filePath.filePath.finalFileName)) {
-                        continue
-                    }
-                }
                 // Line numbers in XCResult starts from `0`, while on web pages like GitHub starts from `1`
                 post(as: level)(message, filePath.filePath, lineNumber.map({ $0 + 1 }) ?? 0)
                 
             } else {
-                if targetFilesNmes != nil {
-                    continue
-                }
                 post(as: level)(message)
             }
             

--- a/Sources/DangerSwiftKantoku/Kantoku+IssueComments.swift
+++ b/Sources/DangerSwiftKantoku/Kantoku+IssueComments.swift
@@ -45,23 +45,33 @@ extension Kantoku {
         
     }
     
-    func post(_ summaries: [PostableIssueSummary], as level: CommentLevel) {
-        
+    func post(_ summaries: [PostableIssueSummary],
+                 as level: CommentLevel,
+          targetFilesNmes: [File]? = nil) {
         for summary in summaries {
             let message = summary.issueMessage
             let filePath = summary.documentLocation?.relativePath(against: workingDirectoryPath)
-            
+
+
             if let filePath = filePath {
                 let lineNumber = filePath.queries?.endingLineNumber
+                if let targetFilesNmes = targetFilesNmes {
+                    if !(targetFilesNmes.contains(filePath.filePath.finalFileName)) {
+                        continue
+                    }
+                }
                 // Line numbers in XCResult starts from `0`, while on web pages like GitHub starts from `1`
                 post(as: level)(message, filePath.filePath, lineNumber.map({ $0 + 1 }) ?? 0)
                 
             } else {
+                if targetFilesNmes != nil {
+                    continue
+                }
                 post(as: level)(message)
             }
             
         }
         
     }
-    
+
 }

--- a/Sources/DangerSwiftKantoku/XCResultParsingConfiguration.swift
+++ b/Sources/DangerSwiftKantoku/XCResultParsingConfiguration.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 public struct XCResultParsingConfiguration {
+
+    public typealias RelativeFilePath = String
+
+    public enum ReportingFileType {
+        case all
+        case modifiedAndCreatedFiles
+        case custom(predicate: (RelativeFilePath) -> Bool)
+    }
     
     public enum CodeCoverageRequirement {
         public struct CoverageThreshold {
@@ -28,19 +36,22 @@ public struct XCResultParsingConfiguration {
     public var parseTestFailures: Bool
     
     public var codeCoverageRequirement: CodeCoverageRequirement
+    public var reportingFileType: ReportingFileType
     
     public init(
         parseBuildWarnings: Bool = true,
         parseBuildErrors: Bool = true,
         parseAnalyzerWarnings: Bool = true,
         parseTestFailures: Bool = true,
-        codeCoverageRequirement: CodeCoverageRequirement = .required(.init(acceptable: 0, recommended: 0.6))
+        codeCoverageRequirement: CodeCoverageRequirement = .required(.init(acceptable: 0, recommended: 0.6)),
+        reportingFileType: ReportingFileType = .all
     ) {
         self.parseBuildWarnings = parseBuildWarnings
         self.parseBuildErrors = parseBuildErrors
         self.parseAnalyzerWarnings = parseAnalyzerWarnings
         self.parseTestFailures = parseTestFailures
         self.codeCoverageRequirement = codeCoverageRequirement
+        self.reportingFileType = reportingFileType
     }
     
 }


### PR DESCRIPTION
1. Adds a enum to specify which files should show warnings
using Danger
2. Add code to generates list of file names from the options
3. Add code to filter warning issues based on file names list
generate above.

@el-hoshino  @novr  let me know if this falls outside the vision/scope for this plugin. 

The Primary use case is for legacy projects which may already have a large number of warnings and maintainer don't have bandwidth to clean up all of them in one go. I am trying to use this plugin for one such project. 

This is Draft of the feature for discussion purposes. i'll refine the code based on PR comments  
