### PR TITLE
fix: Update deprecated APIs in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
             targets: ["DangerSwiftKantoku"]),
     ],
     dependencies: [
-        .package(name: "danger-swift", url: "https://github.com/danger/swift.git", .upToNextMajor(from: "3.0.0")),
-        .package(name: "XCResultKit", url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/danger/swift", from: "3.0.0"),
+        .package(url: "https://github.com/davidahouse/XCResultKit", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -22,7 +22,7 @@ let package = Package(
         .target(
             name: "DangerSwiftKantoku",
             dependencies: [
-                .product(name: "Danger", package: "danger-swift"),
+                .product(name: "Danger", package: "swift"),
                 "XCResultKit",
             ]),
         .testTarget(


### PR DESCRIPTION
## Changes

- fix: package(name:url:_:)' is deprecated: use package(url:_:)

## Context

- Updated deprecated APIs in Package.swift.